### PR TITLE
4: [FEAT] 알림 등록&전송 기능

### DIFF
--- a/src/main/kotlin/medinine/pill_buddy/domain/notification/controller/NotificationController.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/notification/controller/NotificationController.kt
@@ -1,0 +1,32 @@
+package medinine.pill_buddy.domain.notification.controller
+
+import medinine.pill_buddy.domain.notification.dto.NotificationDTO
+import medinine.pill_buddy.domain.notification.service.NotificationService
+import medinine.pill_buddy.log
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/notification")
+class NotificationController(
+    private val notificationService: NotificationService
+) {
+
+    @PostMapping("/{userMedicationId}")
+    fun createNotifications(@PathVariable userMedicationId: Long): ResponseEntity<List<NotificationDTO>> {
+        val notifications = notificationService.createNotifications(userMedicationId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(notifications)
+    }
+
+    @Scheduled(cron = "0 * * * * ?")
+    fun checkAndSendNotifications() {
+        log.info("스케줄링 메서드가 실행되었습니다.")
+        notificationService.sendNotifications()
+    }
+}
+

--- a/src/main/kotlin/medinine/pill_buddy/domain/notification/controller/NotificationController.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/notification/controller/NotificationController.kt
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDateTime
 
 @RestController
 @RequestMapping("/api/notification")
@@ -25,7 +26,7 @@ class NotificationController(
 
     @Scheduled(cron = "0 * * * * ?")
     fun checkAndSendNotifications() {
-        notificationService.sendNotifications()
+        notificationService.sendNotifications(LocalDateTime.now())
     }
 }
 

--- a/src/main/kotlin/medinine/pill_buddy/domain/notification/controller/NotificationController.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/notification/controller/NotificationController.kt
@@ -2,7 +2,6 @@ package medinine.pill_buddy.domain.notification.controller
 
 import medinine.pill_buddy.domain.notification.dto.NotificationDTO
 import medinine.pill_buddy.domain.notification.service.NotificationService
-import medinine.pill_buddy.log
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.scheduling.annotation.Scheduled

--- a/src/main/kotlin/medinine/pill_buddy/domain/notification/controller/NotificationController.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/notification/controller/NotificationController.kt
@@ -25,7 +25,6 @@ class NotificationController(
 
     @Scheduled(cron = "0 * * * * ?")
     fun checkAndSendNotifications() {
-        log.info("스케줄링 메서드가 실행되었습니다.")
         notificationService.sendNotifications()
     }
 }

--- a/src/main/kotlin/medinine/pill_buddy/domain/notification/dto/NotificationDTO.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/notification/dto/NotificationDTO.kt
@@ -1,0 +1,27 @@
+package medinine.pill_buddy.domain.notification.dto
+
+import medinine.pill_buddy.domain.notification.entity.Notification
+import medinine.pill_buddy.domain.userMedication.entity.Frequency
+import java.time.LocalDateTime
+
+data class NotificationDTO(
+    val notificationId: Long? = null,
+    val medicationName: String? = null,
+    val frequency: Frequency? = null,
+    val notificationTime: LocalDateTime? = null,
+    val caretakerId: Long? = null
+) {
+    constructor(notification: Notification) : this(
+        notificationId = notification.id,
+        medicationName = notification.userMedication?.name,
+        frequency = notification.userMedication?.frequency,
+        notificationTime = notification.notificationTime,
+        caretakerId = notification.caretaker?.id
+    )
+
+    companion object {
+        fun convertToDTOs(notifications: List<Notification>): List<NotificationDTO> {
+            return notifications.map { NotificationDTO(it) }
+        }
+    }
+}

--- a/src/main/kotlin/medinine/pill_buddy/domain/notification/provider/SmsProvider.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/notification/provider/SmsProvider.kt
@@ -1,0 +1,32 @@
+package medinine.pill_buddy.domain.notification.provider
+
+import medinine.pill_buddy.log
+import net.nurigo.sdk.NurigoApp
+import net.nurigo.sdk.message.model.Message
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest
+import net.nurigo.sdk.message.service.DefaultMessageService
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.scheduling.annotation.EnableScheduling
+import org.springframework.stereotype.Component
+
+@Component
+@EnableScheduling
+class SmsProvider(
+    @Value("\${sms.api-key}") API_KEY: String,
+    @Value("\${sms.api-secret-key}") API_SECRET_KEY: String,
+    @Value("\${sms.domain}") DOMAIN: String,
+    @Value("\${sms.from-number}") private val FROM: String
+) {
+    private val messageService: DefaultMessageService = NurigoApp.initialize(API_KEY, API_SECRET_KEY, DOMAIN)
+
+    fun sendNotification(phoneNumber: String, medicationName: String, userName: String) {
+        val message = Message().apply {
+            from = FROM
+            to = phoneNumber
+            text = "$userName 님 약 복용 시간입니다: $medicationName"
+        }
+
+        val response = messageService.sendOne(SingleMessageSendingRequest(message))
+        log.info("메세지 전송 성공: $response")
+    }
+}

--- a/src/main/kotlin/medinine/pill_buddy/domain/notification/repository/NotificationRepository.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/notification/repository/NotificationRepository.kt
@@ -1,0 +1,13 @@
+package medinine.pill_buddy.domain.notification.repository
+
+import medinine.pill_buddy.domain.notification.entity.Notification
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDateTime
+
+
+interface NotificationRepository : JpaRepository<Notification, Long> {
+    @Query("SELECT n FROM Notification n WHERE n.notificationTime >= :now AND n.notificationTime < :nowPlusOneMinute")
+    fun findByNotificationTime(@Param("now") now: LocalDateTime, @Param("nowPlusOneMinute") nowPlusOneMinute: LocalDateTime): List<Notification>
+}

--- a/src/main/kotlin/medinine/pill_buddy/domain/notification/service/NotificationService.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/notification/service/NotificationService.kt
@@ -1,0 +1,114 @@
+package medinine.pill_buddy.domain.notification.service
+
+import medinine.pill_buddy.domain.notification.dto.NotificationDTO
+import medinine.pill_buddy.domain.notification.entity.Notification
+import medinine.pill_buddy.domain.notification.provider.SmsProvider
+import medinine.pill_buddy.domain.notification.repository.NotificationRepository
+import medinine.pill_buddy.domain.user.caretaker.repository.CaretakerCaregiverRepository
+import medinine.pill_buddy.domain.userMedication.entity.Frequency
+import medinine.pill_buddy.domain.userMedication.entity.UserMedication
+import medinine.pill_buddy.domain.userMedication.repository.UserMedicationRepository
+import medinine.pill_buddy.global.exception.ErrorCode
+import medinine.pill_buddy.global.exception.PillBuddyCustomException
+import medinine.pill_buddy.log
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+@Transactional
+class NotificationService(
+    private val notificationRepository: NotificationRepository,
+    private val userMedicationRepository: UserMedicationRepository,
+    private val caretakerCaregiverRepository: CaretakerCaregiverRepository,
+    private val smsProvider: SmsProvider
+) {
+    // 주어진 사용자 약물 ID로부터 약물을 찾아 알림을 생성합니다.
+    fun createNotifications(userMedicationId: Long): List<NotificationDTO> {
+        val userMedication = userMedicationRepository.findById(userMedicationId)
+            .orElseThrow { PillBuddyCustomException(ErrorCode.MEDICATION_NOT_FOUND) }
+
+        val notifications = generateNotifications(userMedication)
+        return NotificationDTO.convertToDTOs(notifications)
+    }
+
+    private fun generateNotifications(userMedication: UserMedication): List<Notification> {
+        val notifications = mutableListOf<Notification>()
+        var currentTime = userMedication.startDate
+
+        while (currentTime.isBefore(userMedication.endDate)) {
+            val notification = Notification(
+                notificationTime = currentTime,
+                userMedication = userMedication,
+                caretaker = userMedication.caretaker
+            )
+            notifications.add(notification)
+            currentTime = incrementTime(currentTime, userMedication.frequency)
+        }
+        return notificationRepository.saveAll(notifications)
+    }
+
+    private fun incrementTime(time: LocalDateTime, frequency: Frequency): LocalDateTime {
+        return when (frequency) {
+            Frequency.ONCE_A_DAY -> time.plusDays(1)
+            Frequency.TWICE_A_DAY -> time.plusHours(12)
+            Frequency.THREE_TIMES_A_DAY -> time.plusHours(8)
+            Frequency.WEEKLY -> time.plusWeeks(1)
+            Frequency.BIWEEKLY -> time.plusWeeks(2)
+            Frequency.MONTHLY -> time.plusMonths(1)
+        }
+    }
+
+    // 현재 시간과 1분 후의 시간을 계산하여 등록된 알림을 조회 후 전송합니다.
+    fun sendNotifications() {
+        val now = LocalDateTime.now()
+        val nowPlusOneMinute = now.plusMinutes(1)
+
+        val notifications = notificationRepository.findByNotificationTime(now, nowPlusOneMinute)
+        if (notifications.isNotEmpty()) {
+            log.info("현재 시간: $now. 등록된 알림 개수: ${notifications.size}. 알림을 처리 중입니다.")
+            notifications.forEach { notification ->
+                sendNotificationToCaretaker(notification)
+                sendNotificationToCaregivers(notification)
+                notificationRepository.delete(notification)
+            }
+        } else {
+            log.info("현재 시간: $now. 등록된 알림이 없습니다.")
+        }
+    }
+
+    private fun sendNotificationToCaretaker(notification: Notification) {
+        val phoneNumber = notification.caretaker?.phoneNumber ?: throw PillBuddyCustomException(ErrorCode.PHONE_NUMBER_NOT_FOUND)
+        val (medicationName, userName) = getMedicationAndUserName(notification)
+
+        try {
+            smsProvider.sendNotification(phoneNumber, medicationName, userName)
+            log.info("Caretaker에게 메세지 전송 성공")
+        } catch (e: Exception) {
+            throw PillBuddyCustomException(ErrorCode.MESSAGE_SEND_FAILED)
+        }
+    }
+
+    private fun sendNotificationToCaregivers(notification: Notification) {
+        val caretakerCaregivers = caretakerCaregiverRepository.findByCaretaker(notification.caretaker!!)
+        if (caretakerCaregivers.isNotEmpty()) {
+            val (medicationName, userName) = getMedicationAndUserName(notification)
+
+            caretakerCaregivers.forEach { caretakerCaregiver ->
+                val caregiverPhoneNumber = caretakerCaregiver.caregiver?.phoneNumber ?: throw PillBuddyCustomException(ErrorCode.PHONE_NUMBER_NOT_FOUND)
+                try {
+                    smsProvider.sendNotification(caregiverPhoneNumber, medicationName, userName)
+                    log.info("Caregiver에게 메세지 전송 성공")
+                } catch (e: Exception) {
+                    throw PillBuddyCustomException(ErrorCode.MESSAGE_SEND_FAILED)
+                }
+            }
+        }
+    }
+
+    private fun getMedicationAndUserName(notification: Notification): Pair<String, String> {
+        val medicationName = notification.userMedication?.name ?: throw PillBuddyCustomException(ErrorCode.MEDICATION_NAME_NOT_FOUND)
+        val userName = notification.caretaker?.username ?: throw PillBuddyCustomException(ErrorCode.USER_NAME_NOT_FOUND)
+        return Pair(medicationName, userName)
+    }
+}

--- a/src/main/kotlin/medinine/pill_buddy/domain/notification/service/NotificationService.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/notification/service/NotificationService.kt
@@ -23,7 +23,7 @@ class NotificationService(
     private val caretakerCaregiverRepository: CaretakerCaregiverRepository,
     private val smsProvider: SmsProvider
 ) {
-    // 주어진 사용자 약물 ID로부터 약물을 찾아 알림을 생성합니다.
+    // 주어진 사용자 약 ID로부터 약을 찾아 알림을 생성합니다.
     fun createNotifications(userMedicationId: Long): List<NotificationDTO> {
         val userMedication = userMedicationRepository.findById(userMedicationId)
             .orElseThrow { PillBuddyCustomException(ErrorCode.MEDICATION_NOT_FOUND) }
@@ -60,20 +60,19 @@ class NotificationService(
     }
 
     // 현재 시간과 1분 후의 시간을 계산하여 등록된 알림을 조회 후 전송합니다.
-    fun sendNotifications() {
-        val now = LocalDateTime.now()
-        val nowPlusOneMinute = now.plusMinutes(1)
+    fun sendNotifications(currentTime: LocalDateTime) {
+        val nowPlusOneMinute = currentTime.plusMinutes(1)
 
-        val notifications = notificationRepository.findByNotificationTime(now, nowPlusOneMinute)
+        val notifications = notificationRepository.findByNotificationTime(currentTime, nowPlusOneMinute)
         if (notifications.isNotEmpty()) {
-            log.info("현재 시간: $now. 등록된 알림 개수: ${notifications.size}. 알림을 처리 중입니다.")
+            log.info("현재 시간: $currentTime. 등록된 알림 개수: ${notifications.size}. 알림을 처리 중입니다.")
             notifications.forEach { notification ->
                 sendNotificationToCaretaker(notification)
                 sendNotificationToCaregivers(notification)
                 notificationRepository.delete(notification)
             }
         } else {
-            log.info("현재 시간: $now. 등록된 알림이 없습니다.")
+            log.info("현재 시간: $currentTime. 등록된 알림이 없습니다.")
         }
     }
 

--- a/src/main/kotlin/medinine/pill_buddy/domain/user/caretaker/repository/CaretakerCaregiverRepository.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/user/caretaker/repository/CaretakerCaregiverRepository.kt
@@ -1,0 +1,9 @@
+package medinine.pill_buddy.domain.user.caretaker.repository
+
+import medinine.pill_buddy.domain.user.caretaker.entity.Caretaker
+import medinine.pill_buddy.domain.user.caretaker.entity.CaretakerCaregiver
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CaretakerCaregiverRepository : JpaRepository<CaretakerCaregiver, Long> {
+    fun findByCaretaker(caretaker: Caretaker): List<CaretakerCaregiver>
+}

--- a/src/main/kotlin/medinine/pill_buddy/domain/userMedication/repository/UserMedicationRepository.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/userMedication/repository/UserMedicationRepository.kt
@@ -1,0 +1,6 @@
+package medinine.pill_buddy.domain.userMedication.repository
+
+import medinine.pill_buddy.domain.userMedication.entity.UserMedication
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface UserMedicationRepository : JpaRepository<UserMedication, Long>

--- a/src/main/kotlin/medinine/pill_buddy/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/medinine/pill_buddy/global/exception/ErrorCode.kt
@@ -14,6 +14,7 @@ enum class ErrorCode(
     USER_ALREADY_REGISTERED_LOGIN_ID(HttpStatus.CONFLICT, "이미 등록된 아이디입니다."),
     USER_ALREADY_REGISTERED_PHONE_NUMBER(HttpStatus.CONFLICT, "이미 등록된 전화번호입니다."),
     USER_INVALID_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 사용자 유형입니다."),
+    USER_NAME_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 이름을 찾을 수 없습니다."),
 
     PROFILE_INVALID_FILE(HttpStatus.BAD_REQUEST, "잘못된 이미지 파일입니다."),
     PROFILE_INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "이미지 파일만 업로드할 수 있습니다."),
@@ -33,6 +34,7 @@ enum class ErrorCode(
     MEDICATION_NOT_MODIFIED(HttpStatus.CONFLICT, "약 정보 수정에 실패했습니다."),
     MEDICATION_NOT_VALID(HttpStatus.BAD_REQUEST, "유효하지 않는 약 정보입니다."),
     MEDICATION_IS_NULL(HttpStatus.NOT_FOUND, "현재 복용중인 약이 없습니다."),
+    MEDICATION_NAME_NOT_FOUND(HttpStatus.NOT_FOUND, "약 이름을 찾을 수 없습니다."),
 
     CARETAKER_CAREGIVER_NOT_FOUND(HttpStatus.CONFLICT, "부모 정보 등록에 실패했습니다"),
     CARETAKER_CAREGIVER_REMOVED(HttpStatus.CONFLICT, "부모 정보 삭제에 실패했습니다"),
@@ -64,6 +66,7 @@ enum class ErrorCode(
 
     MESSAGE_SEND_FAILED(HttpStatus.BAD_REQUEST, "메시지 전송에 실패했습니다."),
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알람 정보를 찾을 수 없습니다."),
+    PHONE_NUMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "전화번호를 찾을 수 없습니다."),
 
     RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "저장된 기록을 찾을 수 없습니다"),
     RECORD_NOT_REGISTERED(HttpStatus.CONFLICT, "기록 저장에 실패 했습니다"),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,6 +37,6 @@ logging:
 #
 sms:
   api-key: ${API_KEY}
-  api-secret-key: ${API_SECRET}
+  api-secret-key: ${API_SECRET_KEY}
   domain: https://api.coolsms.co.kr
-  from-number: 01084856953
+  from-number: 01039536296

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,4 +39,4 @@ sms:
   api-key: ${API_KEY}
   api-secret-key: ${API_SECRET}
   domain: https://api.coolsms.co.kr
-  from-number: 01040765951
+  from-number: 01084856953

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,8 +35,8 @@ logging:
 #  serviceKey: ${LOCAL_SERVICE_KEY} #e약은요 API의 encoding된 인증키를 넣어주시면 됩니다
 #  callbackUrl: http://apis.data.go.kr/1471000/DrbEasyDrugInfoService/getDrbEasyDrugList
 #
-#sms:
-#  api-key: ${API_KEY}
-#  api-secret-key: ${API_SECRET}
-#  domain: https://api.coolsms.co.kr
-#  from-number: 01040765951
+sms:
+  api-key: ${API_KEY}
+  api-secret-key: ${API_SECRET}
+  domain: https://api.coolsms.co.kr
+  from-number: 01040765951

--- a/src/test/kotlin/medinine/pill_buddy/domain/notification/controller/NotificationControllerTest.kt
+++ b/src/test/kotlin/medinine/pill_buddy/domain/notification/controller/NotificationControllerTest.kt
@@ -1,0 +1,78 @@
+package medinine.pill_buddy.domain.notification.controller
+
+import medinine.pill_buddy.domain.notification.dto.NotificationDTO
+import medinine.pill_buddy.domain.notification.provider.SmsProvider
+import medinine.pill_buddy.domain.notification.repository.NotificationRepository
+import medinine.pill_buddy.domain.notification.service.NotificationService
+import medinine.pill_buddy.domain.user.caretaker.repository.CaretakerCaregiverRepository
+import medinine.pill_buddy.domain.user.caretaker.repository.CaretakerRepository
+import medinine.pill_buddy.domain.userMedication.entity.Frequency
+import medinine.pill_buddy.domain.userMedication.repository.UserMedicationRepository
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class NotificationControllerTest {
+
+    @Autowired
+    lateinit var mvc: MockMvc
+
+    @MockBean
+    lateinit var notificationService: NotificationService
+
+    @MockBean
+    lateinit var notificationRepository: NotificationRepository
+
+    @MockBean
+    lateinit var userMedicationRepository: UserMedicationRepository
+
+    @MockBean
+    lateinit var caretakerCaregiverRepository: CaretakerCaregiverRepository
+
+    @MockBean
+    lateinit var smsProvider: SmsProvider
+
+    @MockBean
+    lateinit var caretakerRepository: CaretakerRepository
+
+    private val BASE_URL = "/api/notification"
+
+    @Test
+    @DisplayName("알림 생성 테스트")
+    fun createNotifications_test() {
+        // given
+        val userMedicationId = 1L
+        val fixedTime = LocalDateTime.now()
+        val mockNotificationDTO = NotificationDTO(
+            notificationId = 1L,
+            medicationName = "Medication A",
+            frequency = Frequency.ONCE_A_DAY,
+            notificationTime = fixedTime,
+            caretakerId = 1L
+        )
+
+        `when`(notificationService.createNotifications(userMedicationId))
+            .thenReturn(listOf(mockNotificationDTO))
+
+        // when & then
+        mvc.perform(post("$BASE_URL/$userMedicationId")
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isCreated)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(content().json("[{\"notificationId\":1,\"medicationName\":\"Medication A\",\"frequency\":\"ONCE_A_DAY\",\"notificationTime\":\"${fixedTime.format(
+                DateTimeFormatter.ISO_LOCAL_DATE_TIME)}\",\"caretakerId\":1}]"))
+    }
+}

--- a/src/test/kotlin/medinine/pill_buddy/domain/notification/repository/NotificationRepositoryTest.kt
+++ b/src/test/kotlin/medinine/pill_buddy/domain/notification/repository/NotificationRepositoryTest.kt
@@ -1,0 +1,43 @@
+package medinine.pill_buddy.domain.notification.repository
+
+import medinine.pill_buddy.domain.notification.entity.Notification
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import java.time.LocalDateTime
+
+@DataJpaTest
+class NotificationRepositoryTest(
+    @Autowired
+    private var notificationRepository: NotificationRepository
+) {
+    private val fixedTime: LocalDateTime = LocalDateTime.of(2024, 11, 1, 9, 0, 0)
+
+    @BeforeEach
+    fun setUp() {
+        val notification = Notification(
+            notificationTime = fixedTime,
+            userMedication = null,
+            caretaker = null
+        )
+        notificationRepository.save(notification)
+    }
+
+    @Test
+    @DisplayName("현재 시간에 존재하는 알림을 찾을 수 있어야 한다.")
+    fun findByNotificationTime() {
+        // given
+        val now = fixedTime
+        val nowPlusOneMinute = fixedTime.plusMinutes(1)
+
+        // when
+        val notifications = notificationRepository.findByNotificationTime(now, nowPlusOneMinute)
+
+        // then
+        assertThat(notifications).hasSize(1)
+        assertThat(notifications[0].notificationTime).isEqualTo(fixedTime)
+    }
+}

--- a/src/test/kotlin/medinine/pill_buddy/domain/notification/service/NotificationServiceTest.kt
+++ b/src/test/kotlin/medinine/pill_buddy/domain/notification/service/NotificationServiceTest.kt
@@ -1,0 +1,190 @@
+package medinine.pill_buddy.domain.notification.service
+
+import medinine.pill_buddy.domain.notification.provider.SmsProvider
+import medinine.pill_buddy.domain.user.caregiver.entity.Caregiver
+import medinine.pill_buddy.domain.user.caregiver.repository.CaregiverRepository
+import medinine.pill_buddy.domain.user.caretaker.entity.Caretaker
+import medinine.pill_buddy.domain.user.caretaker.entity.CaretakerCaregiver
+import medinine.pill_buddy.domain.user.caretaker.repository.CaretakerCaregiverRepository
+import medinine.pill_buddy.domain.user.caretaker.repository.CaretakerRepository
+import medinine.pill_buddy.domain.userMedication.entity.Frequency
+import medinine.pill_buddy.domain.userMedication.entity.MedicationType
+import medinine.pill_buddy.domain.userMedication.entity.UserMedication
+import medinine.pill_buddy.domain.userMedication.repository.UserMedicationRepository
+import medinine.pill_buddy.global.exception.ErrorCode
+import medinine.pill_buddy.global.exception.PillBuddyCustomException
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.*
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import java.time.LocalDateTime
+
+@SpringBootTest
+class NotificationServiceTest(
+    @Autowired
+    private val notificationService: NotificationService,
+
+    @Autowired
+    private val userMedicationRepository: UserMedicationRepository,
+
+    @Autowired
+    private val caretakerRepository: CaretakerRepository,
+
+    @Autowired
+    private val caretakerCaregiverRepository: CaretakerCaregiverRepository,
+
+    @Autowired
+    private val caregiverRepository: CaregiverRepository
+) {
+    @MockBean
+    private lateinit var smsProvider: SmsProvider
+
+    private val fixedTime: LocalDateTime = LocalDateTime.of(2024, 11, 1, 9, 0, 0)
+
+    @BeforeEach
+    fun setUp() {
+        caretakerCaregiverRepository.deleteAll()
+        caregiverRepository.deleteAll()
+        userMedicationRepository.deleteAll()
+        caretakerRepository.deleteAll()
+
+        for (i in 1..3) {
+            val caretaker = Caretaker(
+                username = "CtUsername$i",
+                loginId = "CtLoginId$i",
+                password = "CtPassword$i",
+                email = "CtEmail$i",
+                phoneNumber = "CtPhoneNumber$i"
+            )
+            caretakerRepository.save(caretaker)
+
+            val userMedication = UserMedication(
+                name = "Medication $i",
+                frequency = Frequency.ONCE_A_DAY,
+                type = MedicationType.MEDICATION,
+                stock = 10,
+                expirationDate = fixedTime.plusMonths(1),
+                startDate = fixedTime,
+                endDate = fixedTime.plusWeeks(1),
+                caretaker = caretaker
+            )
+            userMedicationRepository.save(userMedication)
+
+            val caregiver = Caregiver(
+                username = "CgUsername$i",
+                loginId = "CgLoginId$i",
+                password = "CgPassword$i",
+                email = "CgEmail$i",
+                phoneNumber = "CgPhoneNumber$i"
+            )
+            caregiverRepository.save(caregiver)
+
+            val caretakerCaregiver = CaretakerCaregiver(caretaker = caretaker, caregiver = caregiver)
+            caretakerCaregiverRepository.save(caretakerCaregiver)
+        }
+    }
+
+    @Nested
+    @DisplayName("알림 생성 테스트")
+    inner class CreateNotificationsTests {
+
+        @Test
+        @DisplayName("성공 - 알림 생성 후 NotificationDTO 리스트 반환")
+        fun createNotifications() {
+            //given
+            val userMedicationId = userMedicationRepository.findAll().first().id ?: throw IllegalStateException()
+
+            //when
+            val notificationDTOS = notificationService.createNotifications(userMedicationId)
+
+            //then
+            assertNotNull(notificationDTOS)
+            assertTrue(notificationDTOS.isNotEmpty())
+            assertEquals(7, notificationDTOS.size)
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 약 ID로 알림 생성 시 예외 발생")
+        fun createNotifications_Exception() {
+            //given
+            val userMedicationId = 999L
+
+            //when&then
+            val exception = assertThrows<PillBuddyCustomException> {
+                notificationService.createNotifications(userMedicationId)
+            }
+            assertEquals(ErrorCode.MEDICATION_NOT_FOUND, exception.errorCode)
+        }
+    }
+
+    @Nested
+    @DisplayName("알림 전송 테스트")
+    inner class SendNotificationsTests {
+        @Test
+        @DisplayName("성공 - 알림 전송 성공")
+        fun sendNotifications() {
+            //given
+            val userMedicationId = userMedicationRepository.findAll().first().id ?: throw IllegalStateException()
+            notificationService.createNotifications(userMedicationId)
+
+            val caretaker = caretakerRepository.findAll().first()
+            val medicationName = userMedicationRepository.findAll().first().name
+            val userName = caretaker.username
+            val caregiver = caregiverRepository.findAll().first()
+
+            //when
+            notificationService.sendNotifications(fixedTime)
+
+            //then
+            verify(smsProvider, times(1)).sendNotification(caretaker.phoneNumber, medicationName, userName)
+            verify(smsProvider, times(1)).sendNotification(caregiver.phoneNumber, medicationName, userName)
+        }
+
+        @Test
+        @DisplayName("실패 - 현재 시간에 알림이 존재하지 않아 전송하지 않음")
+        fun sendNotifications_NoNotifications() {
+            // given
+            val noNotificationsTime = fixedTime.plusHours(1)
+
+            val userMedicationId = userMedicationRepository.findAll().first().id ?: throw IllegalStateException()
+            notificationService.createNotifications(userMedicationId)
+
+            val caretaker = caretakerRepository.findAll().first()
+            val medicationName = userMedicationRepository.findAll().first().name
+            val userName = caretaker.username
+
+            // when
+            notificationService.sendNotifications(noNotificationsTime)
+
+            // then
+            verify(smsProvider, never()).sendNotification(caretaker.phoneNumber, medicationName, userName)
+        }
+
+        @Test
+        @DisplayName("실패 - 알림 전송 실패 시 예외 발생")
+        fun sendNotifications_CaretakerSendFailure() {
+            // given
+            val userMedicationId = userMedicationRepository.findAll().first().id ?: throw IllegalStateException()
+            notificationService.createNotifications(userMedicationId)
+
+            val caretaker = caretakerRepository.findAll().first()
+            val medicationName = userMedicationRepository.findAll().first().name
+            val userName = caretaker.username
+
+            doThrow(RuntimeException("SMS 전송 실패")).whenever(smsProvider).sendNotification(caretaker.phoneNumber, medicationName, userName)
+
+            // when & then
+            val exception = assertThrows<PillBuddyCustomException> {
+                notificationService.sendNotifications(fixedTime)
+            }
+            assertEquals(ErrorCode.MESSAGE_SEND_FAILED, exception.errorCode)
+        }
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -37,6 +37,6 @@ jwt:
 #
 sms:
   api-key: ${API_KEY}
-  api-secret-key: ${API_SECRET}
+  api-secret-key: ${API_SECRET_KEY}
   domain: https://api.coolsms.co.kr
   from-number: 01039536296

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -35,8 +35,8 @@ jwt:
 #  serviceKey: ${LOCAL_SERVICE_KEY}
 #  callbackUrl: http://apis.data.go.kr/1471000/DrbEasyDrugInfoService/getDrbEasyDrugList
 #
-#sms:
-#  api-key: ${API_KEY}
-#  api-secret-key: ${API_SECRET}
-#  domain: https://api.coolsms.co.kr
-#  from-number: 01040765951
+sms:
+  api-key: ${API_KEY}
+  api-secret-key: ${API_SECRET}
+  domain: https://api.coolsms.co.kr
+  from-number: 01039536296


### PR DESCRIPTION
## 👩‍💻작업 내용
### 📅 알림 생성 흐름

1. 사용자가 등록한 약물의 ID를 통해 UserMedication 정보를 조회하여 **복용 시작일**과 **종료일**, **복용 빈도**를 확인합니다.
2. 시작일부터 종료일까지의 기간 동안 복용 빈도에 따라  **필요한 알림 개수를 계산합니다** 
3. 수에 맞게 **알림을 모두 생성**하고, 데이터베이스에 저장합니다.

### 📲 알림 시간에 맞춰 메시지를 전송하는 흐름

1. **앱이 실행되면 스케줄러가 1분 간격으로 checkAndSendNotifications 메서드를 실행**합니다.
2. **현재 시간으로 설정되어 있는 알림을 모두 조회**합니다.
3. 조회된 알림이 있을 경우, 각 알림에 대해 다음과 같은 작업을 수행합니다:
- **보호자에게 약 복용 알림 메시지를 전송**합니다.
- 보호자와 연결된 **모든 간병인에게도 동일한 메시지를 전송**합니다.
4. 메시지 전송 성공 여부를 로그로 기록합니다.

## 💬리뷰 요구 사항

## 📃참고 자료
