### PR TITLE
34: [FEAT] 약 복용 확인 및 보호자 메세지 전송 기능

### DIFF
--- a/src/main/kotlin/medinine/pill_buddy/domain/notification/controller/NotificationController.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/notification/controller/NotificationController.kt
@@ -26,6 +26,7 @@ class NotificationController(
     @Scheduled(cron = "0 * * * * ?")
     fun checkAndSendNotifications() {
         notificationService.sendNotifications(LocalDateTime.now())
+        notificationService.checkAndSendForMissedMedications(LocalDateTime.now())
     }
 }
 

--- a/src/main/kotlin/medinine/pill_buddy/domain/notification/provider/SmsProvider.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/notification/provider/SmsProvider.kt
@@ -23,7 +23,18 @@ class SmsProvider(
         val message = Message().apply {
             from = FROM
             to = phoneNumber
-            text = "$userName 님 약 복용 시간입니다: $medicationName"
+            text = "${userName}님 약 복용 시간입니다: $medicationName"
+        }
+
+        val response = messageService.sendOne(SingleMessageSendingRequest(message))
+        log.info("메세지 전송 성공: $response")
+    }
+
+    fun sendCheckNotification(phoneNumber: String, medicationName: String, userName: String) {
+        val message = Message().apply {
+            from = FROM
+            to = phoneNumber
+            text = "${userName}님이 ${medicationName}을(를) 복용하지 않았습니다."
         }
 
         val response = messageService.sendOne(SingleMessageSendingRequest(message))

--- a/src/test/kotlin/medinine/pill_buddy/domain/notification/service/NotificationServiceTest.kt
+++ b/src/test/kotlin/medinine/pill_buddy/domain/notification/service/NotificationServiceTest.kt
@@ -1,6 +1,5 @@
 package medinine.pill_buddy.domain.notification.service
 
-import medinine.pill_buddy.domain.notification.entity.Notification
 import medinine.pill_buddy.domain.notification.provider.SmsProvider
 import medinine.pill_buddy.domain.user.caregiver.entity.Caregiver
 import medinine.pill_buddy.domain.user.caregiver.repository.CaregiverRepository
@@ -14,12 +13,8 @@ import medinine.pill_buddy.domain.userMedication.entity.UserMedication
 import medinine.pill_buddy.domain.userMedication.repository.UserMedicationRepository
 import medinine.pill_buddy.global.exception.ErrorCode
 import medinine.pill_buddy.global.exception.PillBuddyCustomException
+import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.*
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.*
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired


### PR DESCRIPTION
## 👩‍💻작업 내용
사용자가 약을 복용하지 않은 채 15분이 지났다면, 보호자에게 메세지 알림이 전송된다.

## 💬리뷰 요구 사항

## 📃참고 자료
