### PR TITLE
31: [FEAT] 사용자 약 정보 기록 생성 및 수정

### DIFF
--- a/src/main/kotlin/medinine/pill_buddy/domain/record/repository/RecordRepository.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/record/repository/RecordRepository.kt
@@ -1,0 +1,7 @@
+package medinine.pill_buddy.domain.record.repository
+
+import medinine.pill_buddy.domain.record.entity.Record
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface RecordRepository: JpaRepository<Record, Long> {
+}

--- a/src/main/kotlin/medinine/pill_buddy/domain/record/service/RecordService.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/record/service/RecordService.kt
@@ -1,0 +1,8 @@
+package medinine.pill_buddy.domain.record.service
+
+import medinine.pill_buddy.domain.record.dto.RecordDTO
+
+interface RecordService {
+    fun modifyTaken(userMedicationId: Long, recordId: Long): RecordDTO
+    fun registerRecord(userMedicationId: Long): RecordDTO
+}

--- a/src/main/kotlin/medinine/pill_buddy/domain/record/service/RecordServiceImpl.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/record/service/RecordServiceImpl.kt
@@ -1,0 +1,52 @@
+package medinine.pill_buddy.domain.record.service
+
+import medinine.pill_buddy.domain.record.dto.RecordDTO
+import medinine.pill_buddy.domain.record.entity.Record
+import medinine.pill_buddy.domain.record.entity.Taken
+import medinine.pill_buddy.domain.record.repository.RecordRepository
+import medinine.pill_buddy.domain.userMedication.repository.UserMedicationRepository
+import medinine.pill_buddy.global.exception.ErrorCode
+import medinine.pill_buddy.global.exception.PillBuddyCustomException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class RecordServiceImpl (
+    private val userMedicationRepository: UserMedicationRepository,
+    private val recordRepository: RecordRepository
+) : RecordService {
+
+    @Transactional
+    override fun registerRecord(userMedicationId: Long): RecordDTO {
+        val userMedication = userMedicationRepository.findById(userMedicationId)
+            .orElseThrow { PillBuddyCustomException(ErrorCode.MEDICATION_NOT_FOUND) }
+
+        val record = Record(
+            date = LocalDateTime.now(),
+            taken = Taken.UNTAKEN,
+            userMedication = userMedication
+        )
+
+        val savedRecord = recordRepository.save(record)
+        return RecordDTO(savedRecord)
+    }
+
+    @Transactional
+    override fun modifyTaken(userMedicationId: Long, recordId: Long): RecordDTO {
+        val userMedication = userMedicationRepository.findById(userMedicationId)
+            .orElseThrow { PillBuddyCustomException(ErrorCode.MEDICATION_NOT_FOUND) }
+
+        val record = userMedication.records
+            .firstOrNull { it.id == recordId }
+            ?: throw PillBuddyCustomException(ErrorCode.RECORD_NOT_FOUND)
+
+        if (record.taken == Taken.UNTAKEN) {
+            record.takeMedication()
+        } else if (record.taken == Taken.TAKEN) {
+            throw PillBuddyCustomException(ErrorCode.RECORD_ALREADY_TAKEN)
+        }
+
+        return RecordDTO(record)
+    }
+}

--- a/src/main/kotlin/medinine/pill_buddy/domain/user/caretaker/controller/CaretakerController.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/user/caretaker/controller/CaretakerController.kt
@@ -2,9 +2,9 @@ package medinine.pill_buddy.domain.user.caretaker.controller
 
 import lombok.RequiredArgsConstructor
 import medinine.pill_buddy.domain.record.dto.RecordDTO
+import medinine.pill_buddy.domain.record.service.RecordService
 import medinine.pill_buddy.domain.user.caretaker.dto.CaretakerCaregiverDTO
 import medinine.pill_buddy.domain.user.caretaker.service.CaretakerService
-import medinine.pill_buddy.domain.userMedication.entity.MedicationType
 import medinine.pill_buddy.domain.userMedication.service.UserMedicationService
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
@@ -18,7 +18,8 @@ import java.time.LocalDate
 @RequestMapping("/api/caretakers")
 class CaretakerController(
     private val caretakerService: CaretakerService,
-    private val userMedicationService: UserMedicationService
+    private val userMedicationService: UserMedicationService,
+    private val recordService: RecordService
 ) {
     @PostMapping("/{caretakerId}/caregivers/{caregiverId}")
     fun addCaregiver(
@@ -44,5 +45,20 @@ class CaretakerController(
     ): ResponseEntity<List<RecordDTO>> {
         val records = userMedicationService.getUserMedicationRecordsByDate(caretakerId, date.atStartOfDay())
         return ResponseEntity.ok(records)
+    }
+
+    @PostMapping("/user-medications/{userMedicationId}/records")
+    fun addRecord(@PathVariable userMedicationId: Long): ResponseEntity<RecordDTO> {
+        val savedRecordDTO = recordService.registerRecord(userMedicationId)
+        return ResponseEntity.ok(savedRecordDTO)
+    }
+
+    @PutMapping("/user-medications/{userMedicationId}/records/{recordId}")
+    fun updateRecord(
+        @PathVariable userMedicationId: Long,
+        @PathVariable recordId: Long
+    ): ResponseEntity<RecordDTO> {
+        val savedRecordDTO = recordService.modifyTaken(userMedicationId, recordId)
+        return ResponseEntity.ok(savedRecordDTO)
     }
 }

--- a/src/test/kotlin/medinine/pill_buddy/domain/user/caretaker/controller/CaretakerControllerTest.kt
+++ b/src/test/kotlin/medinine/pill_buddy/domain/user/caretaker/controller/CaretakerControllerTest.kt
@@ -2,72 +2,153 @@ package medinine.pill_buddy.domain.user.caretaker.controller
 
 import medinine.pill_buddy.domain.record.dto.RecordDTO
 import medinine.pill_buddy.domain.record.entity.Taken
+import medinine.pill_buddy.domain.record.service.RecordService
+import medinine.pill_buddy.domain.user.caregiver.entity.Caregiver
+import medinine.pill_buddy.domain.user.caretaker.dto.CaretakerCaregiverDTO
+import medinine.pill_buddy.domain.user.caretaker.entity.Caretaker
+import medinine.pill_buddy.domain.user.caretaker.service.CaretakerService
 import medinine.pill_buddy.domain.userMedication.service.UserMedicationService
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
 import org.mockito.Mockito.*
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.MediaType
-import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.http.HttpStatus
 import java.time.LocalDate
 import java.time.LocalDateTime
 
-@SpringBootTest
-@AutoConfigureMockMvc
+@ExtendWith(MockitoExtension::class)
 class CaretakerControllerTest {
 
-    @Autowired
-    private lateinit var mockMvc: MockMvc
+    @Mock
+    private lateinit var caretakerService: CaretakerService
 
-    @MockBean
+    @Mock
     private lateinit var userMedicationService: UserMedicationService
 
-    private lateinit var expectedRecords: List<RecordDTO>
-    private val caretakerId = 1L
-    private val date = LocalDate.of(2024, 9, 25)
+    @Mock
+    private lateinit var recordService: RecordService
+
+    @InjectMocks
+    private lateinit var caretakerController: CaretakerController
+    private lateinit var caretakerCaregiverDTO: CaretakerCaregiverDTO
+    private lateinit var recordDTO: RecordDTO
 
     @BeforeEach
     fun setUp() {
-        expectedRecords = listOf(
-            RecordDTO(
-                id = 1,
-                date = LocalDateTime.of(2024, 9, 25, 9, 0),
-                medicationName = "Aspirin",
-                taken = Taken.TAKEN
+        caretakerCaregiverDTO = CaretakerCaregiverDTO(
+            id = 1L,
+            caretaker = Caretaker(
+                id = 1L,
+                username = "test-caretaker",
+                loginId = "caretaker-login",
+                password = "caretaker-password",
+                email = "caretaker@example.com",
+                phoneNumber = "010-2222-2222"
+            ),
+            caregiver = Caregiver(
+                id = 2L,
+                username = "test-caregiver",
+                loginId = "caregiver-login",
+                password = "caregiver-password",
+                email = "caregiver@example.com",
+                phoneNumber = "010-1111-1111"
             )
         )
-        `when`(userMedicationService.getUserMedicationRecordsByDate(caretakerId, date.atStartOfDay())).thenReturn(
-            expectedRecords
+
+        recordDTO = RecordDTO(
+            id = 1L,
+            date = LocalDateTime.now(),
+            medicationName = "Test Medication",
+            taken = Taken.UNTAKEN
         )
     }
+
 
     @AfterEach
     fun tearDown() {
-        reset(userMedicationService)
+        reset(caretakerService, userMedicationService, recordService)
     }
 
     @Test
-    @DisplayName("약 복용 여부 확인")
-    fun getRecordsByDate() {
-        mockMvc.perform(
-            MockMvcRequestBuilders.get("/api/caretakers/$caretakerId/user-medications/records")
-                .param("date", date.toString())
-                .accept(MediaType.APPLICATION_JSON)
-        )
-            .andExpect(MockMvcResultMatchers.status().isOk)
-            .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[0].id").value(expectedRecords[0].id))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[0].date").value(expectedRecords[0].date.toString()))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[0].medicationName").value(expectedRecords[0].medicationName))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[0].taken").value(expectedRecords[0].taken.toString()))
+    @DisplayName("사용자의 보호자 등록")
+    fun addCaregiver() {
+        // given
+        `when`(caretakerService.register(1L, 2L)).thenReturn(caretakerCaregiverDTO)
 
-        verify(userMedicationService).getUserMedicationRecordsByDate(caretakerId, date.atStartOfDay())
+        // when
+        val response = caretakerController.addCaregiver(1L, 2L)
+
+        // then
+        assertEquals(HttpStatus.CREATED, response.statusCode)
+        assertEquals(caretakerCaregiverDTO, response.body)
+        verify(caretakerService).register(1L, 2L)
+    }
+
+    @Test
+    @DisplayName("사용자의 보호자 삭제")
+    fun deleteCaregiver() {
+        // given
+        doNothing().`when`(caretakerService).remove(1L, 2L)
+
+        // when
+        val response = caretakerController.deleteCaregiver(1L, 2L)
+
+        // then
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals(mapOf("Process" to "Success"), response.body)
+        verify(caretakerService).remove(1L, 2L)
+    }
+
+    @Test
+    @DisplayName("날짜를 통해 복용 여부 확인")
+    fun getRecordsByDate() {
+        // given
+        val date = LocalDate.now()
+        val records = listOf(recordDTO)
+        `when`(userMedicationService.getUserMedicationRecordsByDate(1L, date.atStartOfDay())).thenReturn(records)
+
+        // when
+        val response = caretakerController.getRecordsByDate(1L, date)
+
+        // then
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals(records, response.body)
+        verify(userMedicationService).getUserMedicationRecordsByDate(1L, date.atStartOfDay())
+    }
+
+    @Test
+    @DisplayName("약 정보 기록 생성")
+    fun addRecord() {
+        // given
+        `when`(recordService.registerRecord(3L)).thenReturn(recordDTO)
+
+        // when
+        val response = caretakerController.addRecord(3L)
+
+        // then
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals(recordDTO, response.body)
+        verify(recordService).registerRecord(3L)
+    }
+
+    @Test
+    @DisplayName("약 정보 기록 수정")
+    fun updateRecord() {
+        // given
+        `when`(recordService.modifyTaken(3L, 1L)).thenReturn(recordDTO)
+
+        // when
+        val response = caretakerController.updateRecord(3L, 1L)
+
+        // then
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals(recordDTO, response.body)
+        verify(recordService).modifyTaken(3L, 1L)
     }
 }

--- a/src/test/kotlin/medinine/pill_buddy/domain/user/caretaker/service/CaretakerServiceImplTest.kt
+++ b/src/test/kotlin/medinine/pill_buddy/domain/user/caretaker/service/CaretakerServiceImplTest.kt
@@ -1,37 +1,142 @@
 package medinine.pill_buddy.domain.user.caretaker.service
 
-import medinine.pill_buddy.domain.user.caretaker.dto.CaretakerCaregiverDTO
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.*
-import org.junit.jupiter.api.DisplayName
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import kotlin.test.Test
+import medinine.pill_buddy.domain.user.caregiver.entity.Caregiver
+import medinine.pill_buddy.domain.user.caregiver.repository.CaregiverRepository
+import medinine.pill_buddy.domain.user.caretaker.entity.Caretaker
+import medinine.pill_buddy.domain.user.caretaker.entity.CaretakerCaregiver
+import medinine.pill_buddy.domain.user.caretaker.repository.CaretakerCaregiverRepository
+import medinine.pill_buddy.domain.user.caretaker.repository.CaretakerRepository
+import medinine.pill_buddy.global.exception.ErrorCode
+import medinine.pill_buddy.global.exception.PillBuddyCustomException
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.mockito.BDDMockito.*
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
 
-@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CaretakerServiceImplTest {
 
-    @Autowired
-    private lateinit var caretakerService: CaretakerService
+    @Mock
+    private lateinit var caretakerCaregiverRepository: CaretakerCaregiverRepository
+
+    @Mock
+    private lateinit var caretakerRepository: CaretakerRepository
+
+    @Mock
+    private lateinit var caregiverRepository: CaregiverRepository
+
+    @InjectMocks
+    private lateinit var caretakerService: CaretakerServiceImpl
+    private lateinit var caretaker: Caretaker
+    private lateinit var caregiver: Caregiver
+    private lateinit var caretakerCaregiver: CaretakerCaregiver
+
+    @BeforeAll
+    fun setUpMocks() {
+        MockitoAnnotations.openMocks(this)
+    }
+
+    @BeforeEach
+    fun setUp() {
+        caretaker = Caretaker(
+            id = 1L,
+            username = "test-caretaker",
+            loginId = "caretaker-login",
+            password = "caretaker-password",
+            email = "caretaker@example.com",
+            phoneNumber = "010-2222-2222"
+        )
+
+        caregiver = Caregiver(
+            id = 2L,
+            username = "test-caregiver",
+            loginId = "caregiver-login",
+            password = "caregiver-password",
+            email = "caregiver@example.com",
+            phoneNumber = "010-1111-1111"
+        )
+
+        caretakerCaregiver = CaretakerCaregiver(
+            id = 1L,
+            caretaker = caretaker,
+            caregiver = caregiver
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        reset(caretakerCaregiverRepository, caretakerRepository, caregiverRepository)
+    }
 
     @Test
     @DisplayName("보호자 등록 테스트")
-    fun addCaregiverTest() {
-        val caretakerId = 1L
-        val caregiverId = 3L
+    fun registerTest() {
+        // given
+        given(caretakerRepository.findById(caretaker.id!!)).willReturn(java.util.Optional.of(caretaker))
+        given(caregiverRepository.findById(caregiver.id!!)).willReturn(java.util.Optional.of(caregiver))
+        given(caretakerCaregiverRepository.findByCaretakerIdAndCaregiverId(caretaker.id!!, caregiver.id!!))
+            .willReturn(null)
+        given(caretakerCaregiverRepository.save(any(CaretakerCaregiver::class.java)))
+            .willReturn(caretakerCaregiver)
 
-        val register: CaretakerCaregiverDTO = caretakerService.register(caretakerId, caregiverId)
+        // when
+        val result = caretakerService.register(caretaker.id!!, caregiver.id!!)
 
-        assertThat(register.caretaker?.id).isEqualTo(1L)
-        assertThat(register.caregiver?.id).isEqualTo(3L)
+        // then
+        assertNotNull(result)
+        assertEquals(caretakerCaregiver.id, result.id)
+        assertEquals(caretakerCaregiver.caretaker, result.caretaker)
+        assertEquals(caretakerCaregiver.caregiver, result.caregiver)
+    }
+
+    @Test
+    @DisplayName("보호자 등록 예외 테스트")
+    fun registerThrowExceptionTest() {
+        // given
+        given(caretakerRepository.findById(caretaker.id!!)).willReturn(java.util.Optional.of(caretaker))
+        given(caregiverRepository.findById(caregiver.id!!)).willReturn(java.util.Optional.of(caregiver))
+        given(caretakerCaregiverRepository.findByCaretakerIdAndCaregiverId(caretaker.id!!, caregiver.id!!))
+            .willReturn(caretakerCaregiver)
+
+        // when
+        val exception = assertThrows<PillBuddyCustomException> {
+            caretakerService.register(caretaker.id!!, caregiver.id!!)
+        }
+
+        // then
+        assertEquals(ErrorCode.CARETAKER_CAREGIVER_NOT_REGISTERED, exception.errorCode)
     }
 
     @Test
     @DisplayName("보호자 삭제 테스트")
-    fun removeCaregiverTest() {
-        val caretakerId = 2L
-        val caregiverId = 2L
+    fun removeTest() {
+        // given
+        given(caretakerCaregiverRepository.findByCaretakerIdAndCaregiverId(caretaker.id!!, caregiver.id!!))
+            .willReturn(caretakerCaregiver)
 
-        caretakerService.remove(caretakerId, caretakerId)
+        // when
+        caretakerService.remove(caretaker.id!!, caregiver.id!!)
+
+        // then
+        verify(caretakerCaregiverRepository).delete(caretakerCaregiver)
+    }
+
+    @Test
+    @DisplayName("보호자 삭제 예외 테스트")
+    fun removeThrowException() {
+        // given
+        given(caretakerCaregiverRepository.findByCaretakerIdAndCaregiverId(caretaker.id!!, caregiver.id!!))
+            .willReturn(null)
+
+        // when
+        val exception = assertThrows<PillBuddyCustomException> {
+            caretakerService.remove(caretaker.id!!, caregiver.id!!)
+        }
+
+        // then
+        assertEquals(ErrorCode.CARETAKER_CAREGIVER_NOT_MATCHED, exception.errorCode)
     }
 }

--- a/src/test/kotlin/medinine/pill_buddy/domain/userMedication/service/UserMedicationServiceImplTest.kt
+++ b/src/test/kotlin/medinine/pill_buddy/domain/userMedication/service/UserMedicationServiceImplTest.kt
@@ -64,7 +64,8 @@ class UserMedicationServiceImplTest {
     }
 
     @Test
-    fun `register should save UserMedication and return DTO`() {
+    @DisplayName("등록 테스트")
+    fun registerTest() {
         // given
         given(caretakerRepository.findById(caretaker.id!!)).willReturn(java.util.Optional.of(caretaker))
         given(userMedicationRepository.save(any(UserMedication::class.java))).willReturn(userMedication)
@@ -79,7 +80,8 @@ class UserMedicationServiceImplTest {
     }
 
     @Test
-    fun `register should throw exception when caretaker not found`() {
+    @DisplayName("등록 예외 테스트")
+    fun registerException() {
         // given
         given(caretakerRepository.findById(caretaker.id!!)).willReturn(java.util.Optional.empty())
 
@@ -91,7 +93,8 @@ class UserMedicationServiceImplTest {
     }
 
     @Test
-    fun `retrieve should return list of UserMedicationDTO`() {
+    @DisplayName("약 정보 기록 반환")
+    fun retrieveUserMedication() {
         // given
         given(userMedicationRepository.findByCaretakerId(caretaker.id!!)).willReturn(listOf(userMedication))
 

--- a/src/test/kotlin/medinine/pill_buddy/domain/userMedication/service/UserMedicationServiceImplTest.kt
+++ b/src/test/kotlin/medinine/pill_buddy/domain/userMedication/service/UserMedicationServiceImplTest.kt
@@ -1,83 +1,106 @@
 package medinine.pill_buddy.domain.userMedication.service
 
-import jakarta.transaction.Transactional
+import medinine.pill_buddy.domain.user.caretaker.entity.Caretaker
+import medinine.pill_buddy.domain.user.caretaker.repository.CaretakerRepository
 import medinine.pill_buddy.domain.userMedication.dto.UserMedicationDTO
-import medinine.pill_buddy.domain.userMedication.entity.Frequency
-import medinine.pill_buddy.domain.userMedication.entity.MedicationType
+import medinine.pill_buddy.domain.userMedication.entity.UserMedication
 import medinine.pill_buddy.domain.userMedication.repository.UserMedicationRepository
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.DisplayName
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import java.time.LocalDateTime
-import kotlin.test.Test
+import medinine.pill_buddy.global.exception.ErrorCode
+import medinine.pill_buddy.global.exception.PillBuddyCustomException
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.mockito.BDDMockito.*
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
 
-@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class UserMedicationServiceImplTest {
-    @Autowired
-    private lateinit var userMedicationService: UserMedicationService
 
-    @Autowired
+    @Mock
     private lateinit var userMedicationRepository: UserMedicationRepository
 
-    @Test
-    @Transactional
-    @DisplayName("약 정보 등록 테스트")
-    fun userMedicationRegister() {
-        val caretakerId = 1L
-        val userMedicationDTO = UserMedicationDTO(
-            name = "텐텐",
-            description = "맛있는 영양제",
-            dosage = 3,
-            frequency = Frequency.TWICE_A_DAY,
-            type = MedicationType.SUPPLEMENT,
-            stock = 10,
-            expirationDate = LocalDateTime.now(),
-            startDate = LocalDateTime.now(),
-            endDate = LocalDateTime.now()
+    @Mock
+    private lateinit var caretakerRepository: CaretakerRepository
+
+    @InjectMocks
+    private lateinit var userMedicationService: UserMedicationServiceImpl
+    private lateinit var caretaker: Caretaker
+    private lateinit var userMedicationDTO: UserMedicationDTO
+    private lateinit var userMedication: UserMedication
+
+    @BeforeAll
+    fun setUpMocks() {
+        MockitoAnnotations.openMocks(this)
+    }
+
+    @BeforeEach
+    fun setUp() {
+        caretaker = Caretaker(
+            id = 1L,
+            username = "test-caretaker",
+            loginId = "caretaker-login",
+            password = "caretaker-password",
+            email = "caretaker@example.com",
+            phoneNumber = "010-2222-2222"
         )
 
-        val register = userMedicationService.register(caretakerId, userMedicationDTO)
-        assertThat(register.name).isEqualTo("텐텐")
-        assertThat(register.description).isEqualTo("맛있는 영양제")
-        assertThat(register.dosage).isEqualTo(3)
-        assertThat(register.frequency).isEqualTo(Frequency.TWICE_A_DAY)
-        assertThat(register.type).isEqualTo(MedicationType.SUPPLEMENT)
-        assertThat(register.stock).isEqualTo(10)
+        userMedicationDTO = UserMedicationDTO(
+            id = 1L,
+            name = "Test Medication",
+            description = "Test Description",
+            dosage = 50
+        )
+
+        userMedication = userMedicationDTO.toEntity().apply {
+            caretaker?.let { updateCaretaker(it) }
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        reset(userMedicationRepository, caretakerRepository)
     }
 
     @Test
-    @DisplayName("약 정보 조회")
-    fun userMedicationRetrieve() {
-        val caretakerId = 2L
+    fun `register should save UserMedication and return DTO`() {
+        // given
+        given(caretakerRepository.findById(caretaker.id!!)).willReturn(java.util.Optional.of(caretaker))
+        given(userMedicationRepository.save(any(UserMedication::class.java))).willReturn(userMedication)
 
-        val byCaretakerId = userMedicationRepository.findByCaretakerId(caretakerId)
-        if (byCaretakerId.isEmpty()) {
-            return
-        }
+        // when
+        val result = userMedicationService.register(caretaker.id!!, userMedicationDTO)
 
-        assertThat(byCaretakerId[0].name).isEqualTo("Vitamin D")
-        assertThat(byCaretakerId[0].dosage).isEqualTo(1)
-        assertThat(byCaretakerId[0].description).isEqualTo("Bone health supplement")
-        assertThat(byCaretakerId[0].caretaker?.id).isEqualTo(caretakerId)
+        // then
+        assertNotNull(result)
+        assertEquals(userMedicationDTO.name, result.name)
+        assertEquals(userMedicationDTO.description, result.description)
     }
 
     @Test
-    @Transactional
-    fun userMedicationUpdate() {
-        val caretakerId = 1L
-        val userMedicationId = 1L
-        val byCaretakerId = userMedicationRepository.findByCaretakerId(caretakerId)
+    fun `register should throw exception when caretaker not found`() {
+        // given
+        given(caretakerRepository.findById(caretaker.id!!)).willReturn(java.util.Optional.empty())
 
-        if (byCaretakerId[0].id == userMedicationId) {
-            val userMedication = byCaretakerId[0]
-            userMedication.updateName("aspirin")
-            userMedication.updateDosage(100)
-            userMedication.updateDescription("loose pain")
+        // when & then
+        val exception = assertThrows<PillBuddyCustomException> {
+            userMedicationService.register(caretaker.id!!, userMedicationDTO)
         }
-        val updatedMedication = userMedicationRepository.findById(userMedicationId).get()
-        assertThat(updatedMedication.name).isEqualTo("aspirin")
-        assertThat(updatedMedication.dosage).isEqualTo(100)
-        assertThat(updatedMedication.description).isEqualTo("loose pain")
+        assertEquals(ErrorCode.CARETAKER_NOT_FOUND, exception.errorCode)
+    }
+
+    @Test
+    fun `retrieve should return list of UserMedicationDTO`() {
+        // given
+        given(userMedicationRepository.findByCaretakerId(caretaker.id!!)).willReturn(listOf(userMedication))
+
+        // when
+        val result = userMedicationService.retrieve(caretaker.id!!)
+
+        // then
+        assertNotNull(result)
+        assertEquals(1, result.size)
+        assertEquals(userMedicationDTO.name, result[0].name)
     }
 }


### PR DESCRIPTION
## 👩‍💻작업 내용
1. 마이그레이션
2. 테스트 코드
3. API 테스트

## 💬리뷰 요구 사항
두 기능을 나눠서 이슈를 생성했었는데 이어지는 부분이 있어 같이 마이그레이션 해버렸습니다. 
추가 기능은 없으니 코드는 편하게 봐주시면 됩니다.

## 📃참고 자료
