### PR TITLE
39: [FEAT] 카카오 소셜 로그인 기능

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,12 @@ dependencies {
     // Redis
     implementation ("org.springframework.boot:spring-boot-starter-data-redis")
 
+    // OAuth2
+    implementation ("org.springframework.boot:spring-boot-starter-oauth2-client")
+
+    // Webflux
+    implementation ("org.springframework.boot:spring-boot-starter-webflux")
+
     //nurigo API
     implementation("net.nurigo:sdk:4.2.7")
 

--- a/src/main/kotlin/medinine/pill_buddy/domain/user/caregiver/entity/Caregiver.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/user/caregiver/entity/Caregiver.kt
@@ -16,5 +16,5 @@ class Caregiver(
     loginId: String,
     password: String,
     email: String,
-    phoneNumber: String
+    phoneNumber: String? = null
 ) : User(username, loginId, password, email, phoneNumber, Role.USER)

--- a/src/main/kotlin/medinine/pill_buddy/domain/user/caregiver/repository/CaregiverRepository.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/user/caregiver/repository/CaregiverRepository.kt
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface CaregiverRepository : JpaRepository<Caregiver, Long> {
 
+    fun findByEmail(email: String): Caregiver?
     fun findByLoginId(loginId: String): Caregiver?
     fun existsByLoginId(loginId: String): Boolean
     fun existsByEmail(email: String): Boolean

--- a/src/main/kotlin/medinine/pill_buddy/domain/user/caretaker/entity/Caretaker.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/user/caretaker/entity/Caretaker.kt
@@ -21,5 +21,5 @@ class Caretaker(
     loginId: String,
     password: String,
     email: String,
-    phoneNumber: String
+    phoneNumber: String? = null
 ) : User(username, loginId, password, email, phoneNumber, Role.USER)

--- a/src/main/kotlin/medinine/pill_buddy/domain/user/caretaker/repository/CaretakerRepository.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/user/caretaker/repository/CaretakerRepository.kt
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface CaretakerRepository : JpaRepository<Caretaker, Long> {
 
+    fun findByEmail(email: String): Caretaker?
     fun findByLoginId(loginId: String): Caretaker?
     fun existsByLoginId(loginId: String): Boolean
     fun existsByEmail(email: String): Boolean

--- a/src/main/kotlin/medinine/pill_buddy/domain/user/dto/UserDto.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/user/dto/UserDto.kt
@@ -7,7 +7,7 @@ data class UserDto(
     val username: String,
     val loginId: String,
     val email: String,
-    val phoneNumber: String,
+    val phoneNumber: String?,
     val imageUrl: String
 ) {
     constructor(user: User) : this(

--- a/src/main/kotlin/medinine/pill_buddy/domain/user/dto/UserType.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/user/dto/UserType.kt
@@ -1,5 +1,24 @@
 package medinine.pill_buddy.domain.user.dto
 
+import medinine.pill_buddy.domain.user.entity.User
+import medinine.pill_buddy.global.exception.ErrorCode
+import medinine.pill_buddy.global.exception.PillBuddyCustomException
+
 enum class UserType {
-    CAREGIVER, CARETAKER
+    CAREGIVER, CARETAKER;
+
+    companion object {
+        fun from(user : User) : UserType {
+            val userType = user.javaClass.simpleName.uppercase()
+            return UserType.valueOf(userType)
+        }
+
+        fun from(userType: String) : UserType {
+            return try {
+                UserType.valueOf(userType.uppercase())
+            }  catch (e : IllegalArgumentException) {
+                throw PillBuddyCustomException(ErrorCode.USER_INVALID_TYPE)
+            }
+        }
+    }
 }

--- a/src/main/kotlin/medinine/pill_buddy/domain/user/entity/User.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/user/entity/User.kt
@@ -19,8 +19,8 @@ abstract class User(
     @Column(name = "email", length = 50, unique = true, nullable = false)
     var email: String,
 
-    @Column(name = "phone_number", length = 20, unique = true, nullable = false)
-    var phoneNumber: String,
+    @Column(name = "phone_number", length = 20, unique = true)
+    var phoneNumber: String?,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false)

--- a/src/main/kotlin/medinine/pill_buddy/domain/user/oauth/controller/OAuthController.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/user/oauth/controller/OAuthController.kt
@@ -1,0 +1,34 @@
+package medinine.pill_buddy.domain.user.oauth.controller
+
+import lombok.RequiredArgsConstructor
+import medinine.pill_buddy.domain.user.dto.UserType
+import medinine.pill_buddy.domain.user.oauth.service.KakaoOAuthService
+import medinine.pill_buddy.global.jwt.JwtToken
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api/users/oauth")
+class OAuthController(
+    private val kakaoOAuthService: KakaoOAuthService
+) {
+
+    @GetMapping("/connection")
+    fun loginPage(@RequestParam userType: UserType): ResponseEntity<String> {
+        val location: String = kakaoOAuthService.getConnectionUrl(userType)
+
+        return ResponseEntity.ok(location)
+    }
+
+    @GetMapping("/login/{userType}")
+    fun login(@RequestParam code: String, @PathVariable userType: String): ResponseEntity<JwtToken> {
+        val jwtToken: JwtToken = kakaoOAuthService.login(code, UserType.from(userType))
+
+        return ResponseEntity.ok(jwtToken)
+    }
+}

--- a/src/main/kotlin/medinine/pill_buddy/domain/user/oauth/dto/KakaoProfile.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/user/oauth/dto/KakaoProfile.kt
@@ -1,0 +1,23 @@
+package medinine.pill_buddy.domain.user.oauth.dto
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class KakaoProfile(
+
+    @JsonProperty("id")
+    val id : Long,
+
+    @JsonProperty("properties")
+    val properties : HashMap<String, String>,
+
+    @JsonProperty("kakao_account")
+    val kakaoAccount : KakaoAccount
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class KakaoAccount(
+    @JsonProperty("email")
+    val email : String
+)

--- a/src/main/kotlin/medinine/pill_buddy/domain/user/oauth/dto/KakaoTokenResponse.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/user/oauth/dto/KakaoTokenResponse.kt
@@ -1,0 +1,17 @@
+package medinine.pill_buddy.domain.user.oauth.dto
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class KakaoTokenResponse(
+
+    @JsonProperty("token_type")
+    val tokenType : String,
+
+    @JsonProperty("access_token")
+    val accessToken : String,
+
+    @JsonProperty("refresh_token")
+    val refreshToken : String
+)

--- a/src/main/kotlin/medinine/pill_buddy/domain/user/oauth/service/KakaoClient.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/user/oauth/service/KakaoClient.kt
@@ -1,0 +1,86 @@
+package medinine.pill_buddy.domain.user.oauth.service
+
+import io.netty.handler.codec.http.HttpHeaderValues
+import medinine.pill_buddy.domain.user.dto.UserType
+import medinine.pill_buddy.domain.user.dto.UserType.CAREGIVER
+import medinine.pill_buddy.domain.user.dto.UserType.CARETAKER
+import medinine.pill_buddy.domain.user.oauth.dto.KakaoProfile
+import medinine.pill_buddy.domain.user.oauth.dto.KakaoTokenResponse
+import medinine.pill_buddy.global.exception.ErrorCode
+import medinine.pill_buddy.global.exception.PillBuddyCustomException
+import medinine.pill_buddy.global.oauth.KakaoProperty.KAKAO_AUTHORIZATION_GRANT_TYPE
+import medinine.pill_buddy.global.oauth.KakaoProperty.KAKAO_AUTHORIZATION_URI
+import medinine.pill_buddy.global.oauth.KakaoProperty.KAKAO_CAREGIVER_REDIRECT_URI
+import medinine.pill_buddy.global.oauth.KakaoProperty.KAKAO_CARETAKER_REDIRECT_URI
+import medinine.pill_buddy.global.oauth.KakaoProperty.KAKAO_CLIENT_ID
+import medinine.pill_buddy.global.oauth.KakaoProperty.KAKAO_OAUTH_QUERY_STRING
+import medinine.pill_buddy.global.oauth.KakaoProperty.KAKAO_TOKEN_URI
+import medinine.pill_buddy.global.oauth.KakaoProperty.KAKAO_USER_INFO_URI
+import medinine.pill_buddy.log
+import org.springframework.http.HttpHeaders
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
+
+
+@Component
+class KakaoClient {
+
+    fun getConnectionUrl(userType: UserType): String {
+        val redirectUri = when (userType) {
+            CAREGIVER -> KAKAO_CAREGIVER_REDIRECT_URI
+            CARETAKER -> KAKAO_CARETAKER_REDIRECT_URI
+        }
+        return "$KAKAO_AUTHORIZATION_URI${KAKAO_OAUTH_QUERY_STRING.format(KAKAO_CLIENT_ID, redirectUri)}"
+    }
+
+    fun getAccessToken(code: String): String {
+        val response = WebClient.create(KAKAO_TOKEN_URI).post()
+            .uri { uriBuilder ->
+                uriBuilder
+                    .scheme("https")
+                    .queryParam("grant_type", KAKAO_AUTHORIZATION_GRANT_TYPE)
+                    .queryParam("client_id", KAKAO_CLIENT_ID)
+                    .queryParam("code", code)
+                    .build(true)
+            }
+            .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+            .retrieve()
+            .onStatus({ it.is4xxClientError }) { clientResponse ->
+                log.error("- getAccessToken() => 4xx Client Error: {}", clientResponse.statusCode())
+                Mono.error(RuntimeException("Invalid Parameter"))
+            }
+            .onStatus({ it.is5xxServerError }) { clientResponse ->
+                log.error("- getAccessToken() => 5xx Server Error: {}", clientResponse.statusCode())
+                Mono.error(RuntimeException("Internal Server Error"))
+            }
+            .bodyToMono(KakaoTokenResponse::class.java)
+            .block()
+
+        log.info("kakao token response => $response")
+        return response?.accessToken ?: throw PillBuddyCustomException(ErrorCode.KAKAO_ACCESS_TOKEN_NOT_FOUND)
+    }
+
+    fun getUserInfo(accessToken: String): KakaoProfile {
+        val profile = WebClient.create(KAKAO_USER_INFO_URI).get()
+            .uri { uriBuilder ->
+                uriBuilder.scheme("https").build(true)
+            }
+            .header(HttpHeaders.AUTHORIZATION, "Bearer $accessToken")
+            .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+            .retrieve()
+            .onStatus({ it.is4xxClientError }) { clientResponse ->
+                log.error("- getUserInfo() => 4xx Client Error: {}", clientResponse.statusCode())
+                Mono.error(RuntimeException("Invalid Parameter"))
+            }
+            .onStatus({ it.is5xxServerError }) { clientResponse ->
+                log.error("- getUserInfo() => 5xx Server Error: {}", clientResponse.statusCode())
+                Mono.error(RuntimeException("Internal Server Error"))
+            }
+            .bodyToMono(KakaoProfile::class.java)
+            .block()
+
+        log.info("kakao user info => $profile")
+        return profile ?: throw PillBuddyCustomException(ErrorCode.KAKAO_USER_INFO_NOT_FOUND)
+    }
+}

--- a/src/main/kotlin/medinine/pill_buddy/domain/user/oauth/service/KakaoOAuthService.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/user/oauth/service/KakaoOAuthService.kt
@@ -9,8 +9,6 @@ import medinine.pill_buddy.domain.user.dto.UserType
 import medinine.pill_buddy.domain.user.dto.UserType.CAREGIVER
 import medinine.pill_buddy.domain.user.dto.UserType.CARETAKER
 import medinine.pill_buddy.domain.user.oauth.dto.KakaoProfile
-import medinine.pill_buddy.global.exception.ErrorCode
-import medinine.pill_buddy.global.exception.PillBuddyCustomException
 import medinine.pill_buddy.global.jwt.JwtToken
 import medinine.pill_buddy.global.jwt.JwtTokenProvider
 import org.springframework.beans.factory.annotation.Value

--- a/src/main/kotlin/medinine/pill_buddy/domain/user/oauth/service/KakaoOAuthService.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/user/oauth/service/KakaoOAuthService.kt
@@ -1,0 +1,95 @@
+package medinine.pill_buddy.domain.user.oauth.service
+
+import lombok.RequiredArgsConstructor
+import medinine.pill_buddy.domain.user.caregiver.entity.Caregiver
+import medinine.pill_buddy.domain.user.caregiver.repository.CaregiverRepository
+import medinine.pill_buddy.domain.user.caretaker.entity.Caretaker
+import medinine.pill_buddy.domain.user.caretaker.repository.CaretakerRepository
+import medinine.pill_buddy.domain.user.dto.UserType
+import medinine.pill_buddy.domain.user.dto.UserType.CAREGIVER
+import medinine.pill_buddy.domain.user.dto.UserType.CARETAKER
+import medinine.pill_buddy.domain.user.oauth.dto.KakaoProfile
+import medinine.pill_buddy.global.exception.ErrorCode
+import medinine.pill_buddy.global.exception.PillBuddyCustomException
+import medinine.pill_buddy.global.jwt.JwtToken
+import medinine.pill_buddy.global.jwt.JwtTokenProvider
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+
+
+@Service
+@RequiredArgsConstructor
+class KakaoOAuthService(
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val kakaoClient: KakaoClient,
+    private val caretakerRepository: CaretakerRepository,
+    private val caregiverRepository: CaregiverRepository,
+    private val passwordEncoder: PasswordEncoder
+) : OAuthService {
+
+    @Value("\${oauth.kakao.kakao-password}")
+    private lateinit var oauth2Password: String
+
+    override fun getConnectionUrl(userType: UserType): String {
+        return kakaoClient.getConnectionUrl(userType)
+    }
+
+    override fun login(code: String, userType: UserType): JwtToken {
+        // code 를 통해 카카오 서버로 Token 요청 (POST 요청)
+        val accessToken: String = kakaoClient.getAccessToken(code)
+
+        // Token 을 통해 카카오 서버로 사용자 데이터 요청 (POST 요청)
+        val profile: KakaoProfile = kakaoClient.getUserInfo(accessToken)
+        val email: String = profile.kakaoAccount.email
+
+        // 존재하지 않는 회원일 경우 회원 가입
+        if (isEmailExists(email)) {
+            throw PillBuddyCustomException(ErrorCode.USER_ALREADY_REGISTERED_EMAIL)
+        }
+        userAppend(profile, userType)
+
+        // caregiver or caretaker 조회 후, Jwt 토큰 반환
+        if (userType === CAREGIVER) {
+            val caregiver: Caregiver = caregiverRepository.findByEmail(email)
+                ?: throw PillBuddyCustomException(ErrorCode.USER_NOT_FOUND)
+            return jwtTokenProvider.generateToken(caregiver.loginId)
+        } else {
+            val caretaker: Caretaker = caretakerRepository.findByEmail(email)
+                ?: throw PillBuddyCustomException(ErrorCode.USER_NOT_FOUND)
+            return jwtTokenProvider.generateToken(caretaker.loginId)
+        }
+    }
+
+    private fun userAppend(profile: KakaoProfile, userType: UserType) {
+        val loginId = "kakao_${profile.id}"
+        val encodedPassword = passwordEncoder.encode(oauth2Password)
+        val username: String = profile.properties["nickname"] ?: "user_${profile.id}"
+
+        when (userType) {
+            CARETAKER -> {
+                val caretaker = Caretaker(
+                    username = username,
+                    loginId = loginId,
+                    password = encodedPassword,
+                    email = profile.kakaoAccount.email
+                )
+                caretakerRepository.save(caretaker)
+            }
+
+            CAREGIVER -> {
+                val caregiver = Caregiver(
+                    username = username,
+                    loginId = loginId,
+                    password = encodedPassword,
+                    email = profile.kakaoAccount.email
+                )
+                caregiverRepository.save(caregiver)
+            }
+        }
+    }
+
+    private fun isEmailExists(email: String): Boolean {
+        return caretakerRepository.existsByEmail(email) || caregiverRepository.existsByEmail(email)
+    }
+}

--- a/src/main/kotlin/medinine/pill_buddy/domain/user/oauth/service/OAuthService.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/user/oauth/service/OAuthService.kt
@@ -1,0 +1,10 @@
+package medinine.pill_buddy.domain.user.oauth.service
+
+import medinine.pill_buddy.domain.user.dto.UserType
+import medinine.pill_buddy.global.jwt.JwtToken
+
+
+interface OAuthService {
+    fun getConnectionUrl(userType: UserType): String
+    fun login(code: String, userType: UserType): JwtToken
+}

--- a/src/main/kotlin/medinine/pill_buddy/domain/user/service/UserService.kt
+++ b/src/main/kotlin/medinine/pill_buddy/domain/user/service/UserService.kt
@@ -37,7 +37,7 @@ class UserService(
             updateUsername(userUpdateDto.username ?: user.username)
             updateLoginId(userUpdateDto.loginId ?: user.loginId)
             updateEmail(userUpdateDto.email ?: user.email)
-            updatePhoneNumber(userUpdateDto.phoneNumber ?: user.phoneNumber)
+            (userUpdateDto.phoneNumber ?: user.phoneNumber)?.let { updatePhoneNumber(it) }
         }
         return UserDto(user)
     }

--- a/src/main/kotlin/medinine/pill_buddy/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/medinine/pill_buddy/global/exception/ErrorCode.kt
@@ -22,6 +22,9 @@ enum class ErrorCode(
     PROFILE_CREATE_DIRECTORY_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "업로드 디렉토리를 생성할 수 없습니다."),
     PROFILE_DELETE_FILE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "파일을 삭제할 수 없습니다."),
 
+    KAKAO_ACCESS_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "카카오 엑세스 토큰을 찾을 수 없습니다."),
+    KAKAO_USER_INFO_NOT_FOUND(HttpStatus.BAD_REQUEST, "카카오 사용자 정보를 찾을 수 없습니다."),
+
     JWT_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다."),
     JWT_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "JWT 토큰이 만료되었습니다."),
     JWT_TOKEN_UNSUPPORTED(HttpStatus.BAD_REQUEST, "지원되지 않는 JWT 토큰입니다."),

--- a/src/main/kotlin/medinine/pill_buddy/global/oauth/KakaoProperty.kt
+++ b/src/main/kotlin/medinine/pill_buddy/global/oauth/KakaoProperty.kt
@@ -1,0 +1,74 @@
+package medinine.pill_buddy.global.oauth
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+@Component
+object KakaoProperty {
+
+    @JvmStatic
+    lateinit var KAKAO_CLIENT_ID: String
+        private set
+
+    @JvmStatic
+    lateinit var KAKAO_CAREGIVER_REDIRECT_URI: String
+        private set
+
+    @JvmStatic
+    lateinit var KAKAO_CARETAKER_REDIRECT_URI: String
+        private set
+
+    @JvmStatic
+    lateinit var KAKAO_AUTHORIZATION_GRANT_TYPE: String
+        private set
+
+    @JvmStatic
+    lateinit var KAKAO_AUTHORIZATION_URI: String
+        private set
+
+    @JvmStatic
+    lateinit var KAKAO_TOKEN_URI: String
+        private set
+
+    @JvmStatic
+    lateinit var KAKAO_USER_INFO_URI: String
+        private set
+
+    @JvmStatic
+    val KAKAO_OAUTH_QUERY_STRING = "?response_type=code&client_id=%s&redirect_uri=%s"
+
+    @Value("\${oauth.kakao.client-id}")
+    fun setClientId(clientId: String) {
+        KAKAO_CLIENT_ID = clientId
+    }
+
+    @Value("\${oauth.kakao.caregiver-redirect-uri}")
+    fun setCaregiverRedirectUri(redirectUri: String) {
+        KAKAO_CAREGIVER_REDIRECT_URI = redirectUri
+    }
+
+    @Value("\${oauth.kakao.caretaker-redirect-uri}")
+    fun setCaretakerRedirectUri(redirectUri: String) {
+        KAKAO_CARETAKER_REDIRECT_URI = redirectUri
+    }
+
+    @Value("\${oauth.kakao.authorization-grant-type}")
+    fun setAuthorizationGrantType(authorizationGrantType: String) {
+        KAKAO_AUTHORIZATION_GRANT_TYPE = authorizationGrantType
+    }
+
+    @Value("\${oauth.kakao.authorization-uri}")
+    fun setAuthorizationUri(authorizationUri: String) {
+        KAKAO_AUTHORIZATION_URI = authorizationUri
+    }
+
+    @Value("\${oauth.kakao.token-uri}")
+    fun setTokenUri(tokenUri: String) {
+        KAKAO_TOKEN_URI = tokenUri
+    }
+
+    @Value("\${oauth.kakao.user-info-uri}")
+    fun setUserInfoUri(userInfoUri: String) {
+        KAKAO_USER_INFO_URI = userInfoUri
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,17 @@ jwt:
     access-expiration-time: 300000 # 5분
     refresh-expiration-time: 86400000  # 24시간
 
+oauth:
+  kakao:
+    kakao-password: ${KAKAO_PASSWORD}
+    client-id: ${KAKAO_CLIENT_ID}
+    caregiver-redirect-uri: ${KAKAO_CAREGIVER_REDIRECT_URI}
+    caretaker-redirect-uri: ${KAKAO_CARETAKER_REDIRECT_URI}
+    authorization-grant-type: ${KAKAO_AUTHORIZATION_GRANT_TYPE}
+    authorization-uri: ${KAKAO_AUTHORIZATION_URI}
+    token-uri: ${KAKAO_TOKEN_URI}
+    user-info-uri: ${KAKAO_USER_INFO_URI}
+
 file:
   path: test-upload
 

--- a/src/test/kotlin/medinine/pill_buddy/domain/notification/service/NotificationServiceTest.kt
+++ b/src/test/kotlin/medinine/pill_buddy/domain/notification/service/NotificationServiceTest.kt
@@ -143,8 +143,8 @@ class NotificationServiceTest(
             notificationService.sendNotifications(fixedTime)
 
             //then
-            verify(smsProvider, times(1)).sendNotification(caretaker.phoneNumber, medicationName, userName)
-            verify(smsProvider, times(1)).sendNotification(caregiver.phoneNumber, medicationName, userName)
+            verify(smsProvider, times(1)).sendNotification(caretaker.phoneNumber!!, medicationName, userName)
+            verify(smsProvider, times(1)).sendNotification(caregiver.phoneNumber!!, medicationName, userName)
         }
 
         @Test
@@ -164,7 +164,7 @@ class NotificationServiceTest(
             notificationService.sendNotifications(noNotificationsTime)
 
             // then
-            verify(smsProvider, never()).sendNotification(caretaker.phoneNumber, medicationName, userName)
+            verify(smsProvider, never()).sendNotification(caretaker.phoneNumber!!, medicationName, userName)
         }
 
         @Test
@@ -178,7 +178,7 @@ class NotificationServiceTest(
             val medicationName = userMedicationRepository.findAll().first().name
             val userName = caretaker.username
 
-            doThrow(RuntimeException("SMS 전송 실패")).whenever(smsProvider).sendNotification(caretaker.phoneNumber, medicationName, userName)
+            doThrow(RuntimeException("SMS 전송 실패")).whenever(smsProvider).sendNotification(caretaker.phoneNumber!!, medicationName, userName)
 
             // when & then
             val exception = assertThrows<PillBuddyCustomException> {

--- a/src/test/kotlin/medinine/pill_buddy/domain/user/oauth/service/KakaoOAuthServiceTest.kt
+++ b/src/test/kotlin/medinine/pill_buddy/domain/user/oauth/service/KakaoOAuthServiceTest.kt
@@ -1,0 +1,108 @@
+package medinine.pill_buddy.domain.user.oauth.service
+
+import medinine.pill_buddy.domain.user.caregiver.entity.Caregiver
+import medinine.pill_buddy.domain.user.caregiver.repository.CaregiverRepository
+import medinine.pill_buddy.domain.user.caretaker.repository.CaretakerRepository
+import medinine.pill_buddy.domain.user.dto.UserType
+import medinine.pill_buddy.domain.user.oauth.dto.KakaoAccount
+import medinine.pill_buddy.domain.user.oauth.dto.KakaoProfile
+import medinine.pill_buddy.global.jwt.JwtToken
+import medinine.pill_buddy.global.jwt.JwtTokenProvider
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.test.util.ReflectionTestUtils
+
+@ExtendWith(MockitoExtension::class)
+class KakaoOAuthServiceTest {
+
+    @InjectMocks
+    lateinit var kakaoOAuthService: KakaoOAuthService
+    @Mock
+    lateinit var jwtTokenProvider: JwtTokenProvider
+    @Mock
+    lateinit var kakaoClient: KakaoClient
+    @Mock
+    lateinit var caregiverRepository: CaregiverRepository
+    @Mock
+    lateinit var caretakerRepository: CaretakerRepository
+    @Mock
+    lateinit var passwordEncoder: PasswordEncoder
+
+    @Test
+    @DisplayName("소셜 계정을 처음 연동 시 회원 가입 후 토큰을 발급한다.")
+    fun login_when_user_does_not_exist() {
+        // given
+        val code = "test_code"
+        val userType = UserType.CAREGIVER
+        val accessToken = "accessToken"
+        val profile = KakaoProfile(
+            kakaoAccount = KakaoAccount(email = "test@example.com"),
+            properties = HashMap(mapOf("nickname" to "TestUser")),
+            id = 1
+        )
+        val caregiver = Caregiver(
+            username = "TestUser",
+            loginId = "kakao_1",
+            password = "encodedPassword",
+            email = "test@example.com"
+        )
+        val expected = JwtToken("Bearer", "access_token", "refresh_token")
+        ReflectionTestUtils.setField(kakaoOAuthService, "oauth2Password", "encodedPassword")
+
+        `when`(kakaoClient.getAccessToken(code)).thenReturn(accessToken)
+        `when`(kakaoClient.getUserInfo(accessToken)).thenReturn(profile)
+        `when`(caregiverRepository.existsByEmail("test@example.com")).thenReturn(false)
+        `when`(caregiverRepository.findByEmail("test@example.com")).thenReturn(caregiver)
+        `when`(passwordEncoder.encode(anyString())).thenReturn("encodedPassword")
+        `when`(jwtTokenProvider.generateToken("kakao_1")).thenReturn(expected)
+
+        // When
+        val result = kakaoOAuthService.login(code, userType)
+
+        // Then
+        verify(caregiverRepository).save(any(Caregiver::class.java))
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    @DisplayName("소셜 로그인 시 토큰을 발급한다.")
+    fun login_when_user_login() {
+        // given
+        val code = "test_code"
+        val userType = UserType.CAREGIVER
+        val accessToken = "accessToken"
+        val profile = KakaoProfile(
+            kakaoAccount = KakaoAccount(email = "test@example.com"),
+            properties = HashMap(mapOf("nickname" to "ExistingUser")),
+            id = 1
+        )
+        val caregiver = Caregiver(
+            username = "ExistingUser",
+            loginId = "kakao_1",
+            password = "encodedPassword",
+            email = "test@example.com"
+        )
+        val expected = JwtToken("Bearer", "access_token", "refresh_token")
+
+        ReflectionTestUtils.setField(kakaoOAuthService, "oauth2Password", "encodedPassword")
+        `when`(kakaoClient.getAccessToken(code)).thenReturn(accessToken)
+        `when`(kakaoClient.getUserInfo(accessToken)).thenReturn(profile)
+        `when`(caregiverRepository.existsByEmail("test@example.com")).thenReturn(true)
+        `when`(caregiverRepository.findByEmail("test@example.com")).thenReturn(caregiver)
+        `when`(jwtTokenProvider.generateToken("kakao_1")).thenReturn(expected)
+
+        // When
+        val result = kakaoOAuthService.login(code, userType)
+
+        // Then
+        verify(caregiverRepository, never()).save(any(Caregiver::class.java))
+        assertThat(result).isEqualTo(expected)
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -27,6 +27,17 @@ jwt:
     access-expiration-time: 1800000
     refresh-expiration-time: 18000000
 
+oauth:
+  kakao:
+    kakao-password: ${KAKAO_PASSWORD}
+    client-id: ${KAKAO_CLIENT_ID}
+    caregiver-redirect-uri: ${KAKAO_CAREGIVER_REDIRECT_URI}
+    caretaker-redirect-uri: ${KAKAO_CARETAKER_REDIRECT_URI}
+    authorization-grant-type: ${KAKAO_AUTHORIZATION_GRANT_TYPE}
+    authorization-uri: ${KAKAO_AUTHORIZATION_URI}
+    token-uri: ${KAKAO_TOKEN_URI}
+    user-info-uri: ${KAKAO_USER_INFO_URI}
+
 file:
   path: test-upload
 


### PR DESCRIPTION
## 👩‍💻작업 내용
카카오 소셜 로그인 기능 구현
<img width="600" alt="image" src="https://github.com/user-attachments/assets/ea772879-df64-4394-bdd9-2df5ca6aa183">

카카오 로그인 흐름
1. 프론트에서 /api/users/oauth/connection 으로 GET 요청 (원래는 프론트가 구현)
2. 서버에서 카카오 로그인 URL 전달 (`KakaoClient.getConnectionUrl` 메서드)
 - kakao 개발자 애플리케이션에서 받은 `API KEY, redirectUrl` 을 쿼리 파라미터로 포함하여 전송함
3. 사용자는 로그인 성공 시 자동으로 인증 코드를 포함하여 `redirectUrl`로 리다이렉트됨
- 사용자, 보호자에 따라 Url 을 나눴습니다.
4. 서버에서 redirect  요청을 처리 `OAuthController.login()`
5. 카카오 서버로 인증 코드를 포함하여 POST 요청을 보냄 -> Jwt 토큰을 전달받음
6. 다시 전달받은 Jwt토큰을 포함하여 카카오 서버로 POST 요청을 보냄 -> 사용자 정보를 전달받음
7. 사용자 정보 (email)을 바탕으로 서버에 사용자가 회원인지 판단하고, 회원이 아니면 자동 회원가입
8. 등록된 사용자 정보를 조회해서 새로운 Jwt 토큰을 반환

## 💬리뷰 요구 사항
제가 참고한 자료에서 WebFlux 라이브러리의 WebClient 를 통해서 Restemplate 가 아닌 WebClient 코드로 요청 메서드를 작성하였습니다. 궁금하신 부분이 있으시면 언제든 물어봐주세요!!

또한 한눈에 봐도 SRP를 깨는 클래스가 많이 보이네요... 네이버 소셜 로그인을 구현하고 인터페이스를 통해 클래스를 더 분리해보겠습니다... !

+) 추가로 카카오 로그인으로 휴대폰 번호를 가져올 수 없어서 소희님과 얘기를 통해 휴대폰 번호를 nullable 하게 하도록 수정하였습니다.
## 📃참고 자료
https://ddonghyeo.tistory.com/16
https://velog.io/@kbk3771/Spring-Boot-%EC%B9%B4%EC%B9%B4%EC%98%A4-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0
https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api